### PR TITLE
failover: add config to disable automatic failover

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type AdminConfig struct {
 type FailOverConfig struct {
 	PingIntervalSeconds int   `yaml:"ping_interval_seconds"`
 	MaxPingCount        int64 `yaml:"max_ping_count"`
+	Disabled            bool  `yaml:"disabled"`
 }
 
 type ControllerConfig struct {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -188,7 +188,8 @@ func (c *Controller) addCluster(namespace, clusterName string) {
 
 	cluster := NewClusterChecker(c.clusterStore, namespace, clusterName).
 		WithPingInterval(time.Duration(c.config.FailOver.PingIntervalSeconds) * time.Second).
-		WithMaxFailureCount(c.config.FailOver.MaxPingCount)
+		WithMaxFailureCount(c.config.FailOver.MaxPingCount).
+		WithDisableAutomaticFailover(c.config.FailOver.Disabled)
 	cluster.Start()
 
 	c.mu.Lock()


### PR DESCRIPTION
Add a kvrocks config to disable automatic failover. This is useful in cases where you never want to lose writes that could be missed if the primary crashed before it replicated those writes to the replicas.